### PR TITLE
Clarified multiple subnets association purpose

### DIFF
--- a/doc_source/what-is.md
+++ b/doc_source/what-is.md
@@ -29,7 +29,7 @@ The following are the key concepts for Client VPN:
 The Client VPN endpoint is the resource that you create and conﬁgure to enable and manage client VPN sessions\. It is the resource where all client VPN sessions are terminated\.
 
 **Target network**  
-A target network is the network that you associate with a Client VPN endpoint\. A subnet from a VPC is a target network\. Associating a subnet with a Client VPN endpoint enables you to establish VPN sessions\. You can associate multiple subnets with a Client VPN endpoint\. All subnets must be from the same VPC\. Each subnet must belong to a different Availability Zone\.
+A target network is the network that you associate with a Client VPN endpoint\. A subnet from a VPC is a target network\. Associating a subnet with a Client VPN endpoint enables you to establish VPN sessions\. You can associate multiple subnets with a Client VPN endpoint for high availability\. All subnets must be from the same VPC\. Each subnet must belong to a different Availability Zone\.
 
 **Route**  
 Each Client VPN endpoint has a route table that describes the available destination network routes\. Each route in the route table specifies the path for traﬃc to speciﬁc resources or networks\.


### PR DESCRIPTION
As of now, its not clear why would you want multiple subnets assigned to endpoint. One does not need to associate all subnets in VPC to have access to them - just one is enough. Multiple subnets are assigned just for high availability so if one of the zones to go down, vpn will be still active.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
