### PR TITLE
change acmes import to use fileb instead of file

### DIFF
--- a/doc_source/client-authentication.md
+++ b/doc_source/client-authentication.md
@@ -93,11 +93,11 @@ The following procedure uses OpenVPN easy\-rsa to generate the server and client
 1. Upload the server certificate and key and the client certificate and key to ACM\. The following commands use the AWS CLI\.
 
    ```
-   $ aws acm import-certificate --certificate file://server.crt --private-key file://server.key --certificate-chain file://ca.crt --region region
+   $ aws acm import-certificate --certificate fileb://server.crt --private-key fileb://server.key --certificate-chain fileb://ca.crt --region region
    ```
 
    ```
-   $ aws acm import-certificate --certificate file://client1.domain.tld.crt --private-key file://client1.domain.tld.key --certificate-chain file://ca.crt --region region
+   $ aws acm import-certificate --certificate fileb://client1.domain.tld.crt --private-key fileb://client1.domain.tld.key --certificate-chain fileb://ca.crt --region region
    ```
 
    To upload the certificates using the ACM console, see [Import a Certificate](https://docs.aws.amazon.com/acm/latest/userguide/import-certificate-api-cli.html) in the *AWS Certificate Manager User Guide*\.


### PR DESCRIPTION
Following this guide failed due to this https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-binaryparam
and this
https://github.com/aws/aws-cli/issues/4978

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
